### PR TITLE
Disable link-time code generation for MSVC Debug builds

### DIFF
--- a/openloco.common.props
+++ b/openloco.common.props
@@ -71,7 +71,6 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Every time I do a debug build, I get a warning message from the linker telling me that /LTCG is doing nothing and that removing it from the options will speed up the linking process.

```
LINK : /LTCG specified but no code generation required; remove /LTCG from the link command line to improve linker performance
```

(I believe this is due to LTCG being incompatible with incremental linking; and AFAIK incremental linking is enabled in debug builds by default.)

So, this PR simply disables the LTCG flag for the project's Debug config.