### PR TITLE
Enhance/fix some minor things

### DIFF
--- a/src/openloco/interop/hook.cpp
+++ b/src/openloco/interop/hook.cpp
@@ -191,7 +191,7 @@ namespace openloco::interop
         register_hook(
             address,
             [](registers& regs) -> uint8_t {
-                std::printf("                    fn %" PRIuPTR "\n", passAddress);
+                std::printf("                    fn %08" PRIXPTR "\n", passAddress);
                 return 0;
             });
     }

--- a/src/openloco/interop/interop.cpp
+++ b/src/openloco/interop/interop.cpp
@@ -26,18 +26,6 @@
 #define DISABLE_OPT
 #endif // defined(__GNUC__)
 
-#ifdef USE_MMAP
-#if defined(PLATFORM_64BIT)
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x200000000)
-#elif defined(PLATFORM_32BIT)
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x09000000)
-#else
-#error "Unknown platform"
-#endif
-#else
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x8A4000)
-#endif
-
 namespace openloco::interop
 {
     registers::registers()
@@ -305,11 +293,6 @@ namespace openloco::interop
             &registers.esi,
             &registers.edi,
             &registers.ebp);
-    }
-
-    uintptr_t remap_address(uintptr_t locoAddress)
-    {
-        return GOOD_PLACE_FOR_DATA_SEGMENT - 0x8A4000 + locoAddress;
     }
 
     void read_memory(uint32_t address, void* data, size_t size)

--- a/src/openloco/interop/interop.cpp
+++ b/src/openloco/interop/interop.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cinttypes>
 #include <cstring>
 #include <stdexcept>
 
@@ -346,7 +347,7 @@ namespace openloco::interop
             if (left != right)
             {
                 uint32_t addr = lhs.begin + i;
-                std::printf("0x%06X: %02X  %02X\n", addr, (uint8_t)left, (uint8_t)right);
+                std::printf("0x%06" PRIX32 ": %02" PRIX8 "  %02" PRIX8 "\n", addr, (uint8_t)left, (uint8_t)right);
             }
         }
     }

--- a/src/openloco/interop/interop.hpp
+++ b/src/openloco/interop/interop.hpp
@@ -16,6 +16,18 @@ namespace std
 }
 #endif
 
+#ifdef USE_MMAP
+#if defined(PLATFORM_64BIT)
+#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x200000000)
+#elif defined(PLATFORM_32BIT)
+#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x09000000)
+#else
+#error "Unknown platform"
+#endif
+#else
+#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x8A4000)
+#endif
+
 namespace openloco::interop
 {
 
@@ -86,10 +98,13 @@ namespace openloco::interop
     assert_struct_size(registers, 7 * 4);
 #pragma pack(pop)
 
-    uintptr_t remap_address(uintptr_t locoAddress);
+    constexpr uintptr_t remap_address(uintptr_t locoAddress)
+    {
+        return GOOD_PLACE_FOR_DATA_SEGMENT - 0x8A4000 + locoAddress;
+    }
 
     template<uint32_t TAddress, typename T>
-    T& addr()
+    constexpr T& addr()
     {
         return *((T*)remap_address(TAddress));
     }
@@ -146,7 +161,7 @@ namespace openloco::interop
             return &(addr<TAddress, T>());
         }
 
-        size_t size()
+        constexpr size_t size()
         {
             return TSize;
         }

--- a/src/openloco/interop/interop.hpp
+++ b/src/openloco/interop/interop.hpp
@@ -17,21 +17,8 @@ namespace std
 }
 #endif
 
-#ifdef USE_MMAP
-#if defined(PLATFORM_64BIT)
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x200000000)
-#elif defined(PLATFORM_32BIT)
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x09000000)
-#else
-#error "Unknown platform"
-#endif
-#else
-#define GOOD_PLACE_FOR_DATA_SEGMENT ((uintptr_t)0x8A4000)
-#endif
-
 namespace openloco::interop
 {
-
 #pragma pack(push, 1)
     /**
     * x86 register structure, only used for easy interop to Locomotion code.
@@ -99,9 +86,21 @@ namespace openloco::interop
     assert_struct_size(registers, 7 * 4);
 #pragma pack(pop)
 
+#ifndef USE_MMAP
+    constexpr uintptr_t GOOD_PLACE_FOR_DATA_SEGMENT = 0x008A4000;
+#else
+#if defined(PLATFORM_32BIT)
+    constexpr uintptr_t GOOD_PLACE_FOR_DATA_SEGMENT = 0x09000000;
+#elif defined(PLATFORM_64BIT)
+    constexpr uintptr_t GOOD_PLACE_FOR_DATA_SEGMENT = 0x200000000;
+#else
+#error "Unknown platform"
+#endif
+#endif
+
     constexpr uintptr_t remap_address(uintptr_t locoAddress)
     {
-        return GOOD_PLACE_FOR_DATA_SEGMENT - 0x8A4000 + locoAddress;
+        return GOOD_PLACE_FOR_DATA_SEGMENT - 0x008A4000 + locoAddress;
     }
 
     template<uint32_t TAddress, typename T>

--- a/src/openloco/interop/interop.hpp
+++ b/src/openloco/interop/interop.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <stdexcept>
 #include <vector>
 
 #define assert_struct_size(x, y) static_assert(sizeof(x) == (y), "Improper struct size")
@@ -154,6 +155,18 @@ namespace openloco::interop
         operator T*()
         {
             return get();
+        }
+
+        T& operator[](int idx)
+        {
+#ifndef NDEBUG
+            if (idx < 0 || static_cast<size_t>(idx) >= size())
+            {
+                throw std::out_of_range("loco_global_array: bounds check violation!");
+            }
+#endif
+
+            return (get())[idx];
         }
 
         T* get()


### PR DESCRIPTION
- Funcs like `remap_address` can now be used at compile time, which is sometimes important
- `loco_global_array` now has bounds checking based on the array dimension specified when it was declared (only in debug builds)
- Some cases of cross-platform inconsistencies in format specifiers have been fixed via `<cinttypes>`