### PR TITLE
Mingw exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,20 @@ endif (APPLE)
 
 set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Warray-bounds -Waddress -Wchar-subscripts -Wenum-compare")
 
-set(OBJ_FORMAT "elf32-i386")
+if (MINGW)
+    set(OBJ_FORMAT "pe-i386")
+    set(LINKER_PLATFORM "mingw")
+else ()
+    set(OBJ_FORMAT "elf32-i386")
+    set(LINKER_PLATFORM "linux")
+endif ()
 set(LINKER_SCRIPT "ld_script_i386.xc")
 
 
 # Handle creating the rct2 text and data files on OS X and Linux
 # See details in src/openrct2.c:openrct2_setup_rct2_segment for how the values
 # were derived.
-if (UNIX)
+if (UNIX OR MINGW)
     set(OLOCO_EXE ${CMAKE_CURRENT_SOURCE_DIR}/loco.exe)
     set(OLOCO_TEXT ${CMAKE_BINARY_DIR}/openloco_text)
     set(OLOCO_DATA ${CMAKE_BINARY_DIR}/openloco_data)
@@ -55,13 +61,13 @@ if (UNIX)
         # bespoke linker script so they can be placed at predefined VMAs.
         add_custom_command(
             OUTPUT openloco_text_section.o
-            COMMAND objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_TEXT}\" openloco_text_section.o --rename-section .data=.loco_text,contents,alloc,load,code --writable-text
+            COMMAND ${COMPILER_PREFIX}objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_TEXT}\" openloco_text_section.o --rename-section .data=.loco_text,contents,alloc,load,code --writable-text
             DEPENDS segfiles
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
         add_custom_command(
             OUTPUT openloco_data_section.o
-            COMMAND objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_DATA}\" openloco_data_section.o --rename-section .data=.loco_data,contents,alloc,load,readonly,data
+            COMMAND ${COMPILER_PREFIX}objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_DATA}\" openloco_data_section.o --rename-section .data=.loco_data,contents,alloc,load,readonly,data
             DEPENDS segfiles
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
@@ -74,10 +80,10 @@ if (UNIX)
         )
         # can't use GLOB here, as the files don't exist yet at cmake-time
         set(LOCO_SECTIONS "${CMAKE_BINARY_DIR}/openloco_data_section.o" "${CMAKE_BINARY_DIR}/openloco_text_section.o")
-        set(LOCO_SEGMENT_LINKER_FLAGS "-Wl,-T,\"${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/${LINKER_SCRIPT}\"")
+        set(LOCO_SEGMENT_LINKER_FLAGS "-Wl,-T,\"${CMAKE_CURRENT_SOURCE_DIR}/distribution/${LINKER_PLATFORM}/${LINKER_SCRIPT}\"")
     endif ()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LOCO_SEGMENT_LINKER_FLAGS}")
-endif (UNIX)
+endif ()
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LOCO_SEGMENT_LINKER_FLAGS}")
 
 set(DEBUG_LEVEL 0 CACHE STRING "Select debug level for compilation. Use value in range 0–3.")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
@@ -123,25 +129,29 @@ set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/openloco/interop/in
 set(CMAKE_CXX_STANDARD 17)
 
 if (MINGW)
-    add_library(${PROJECT} ${OLOCO_SOURCES})
-    target_link_libraries(${PROJECT} winmm)
-else ()
-    add_executable(${PROJECT} ${OLOCO_SOURCES} ${OLOCO_MM_SOURCES} ${LOCO_SECTIONS})
+    add_library(libopenloco ${OLOCO_SOURCES})
+    target_link_libraries(libopenloco winmm)
 endif ()
+add_executable(${PROJECT} ${OLOCO_SOURCES} ${OLOCO_MM_SOURCES} ${LOCO_SECTIONS})
+target_link_libraries(${PROJECT} winmm)
 target_link_libraries(${PROJECT} SDL2 ${SDL2LIBS})
+target_link_libraries(libopenloco SDL2 ${SDL2LIBS})
 if (NOT MINGW)
     add_dependencies(${PROJECT} segfiles)
 endif()
 target_compile_definitions(${PROJECT} PRIVATE _NO_LOCO_WIN32_=1)
 if (USE_BOOST_FILESYSTEM)
     target_link_libraries(${PROJECT} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+    target_link_libraries(libopenloco ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
     target_compile_definitions(${PROJECT} PRIVATE BOOST_SYSTEM_NO_DEPRECATED=1 BOOST_FILESYSTEM_NO_DEPRECATED=1 _OPENLOCO_USE_BOOST_FS_=1)
+    target_compile_definitions(libopenloco PRIVATE BOOST_SYSTEM_NO_DEPRECATED=1 BOOST_FILESYSTEM_NO_DEPRECATED=1 _OPENLOCO_USE_BOOST_FS_=1)
 else()
 	target_link_libraries(${PROJECT} stdc++fs)
 endif()
 
 if (MINGW)
 	target_compile_definitions(${PROJECT} PRIVATE _WIN32_WINNT=0x0600)
+    target_compile_definitions(libopenloco PRIVATE _WIN32_WINNT=0x0600)
 endif()
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (UNIX OR MINGW)
         )
         add_custom_command(
             OUTPUT openloco_data_section.o
-            COMMAND ${COMPILER_PREFIX}objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_DATA}\" openloco_data_section.o --rename-section .data=.loco_data,contents,alloc,load,readonly,data
+            COMMAND ${COMPILER_PREFIX}objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_DATA}\" openloco_data_section.o --rename-section .data=.loco_data,contents,alloc,load,data
             DEPENDS segfiles
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (UNIX)
         # bespoke linker script so they can be placed at predefined VMAs.
         add_custom_command(
             OUTPUT openloco_text_section.o
-            COMMAND objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_TEXT}\" openloco_text_section.o --rename-section .data=.loco_text,contents,alloc,load,readonly,code
+            COMMAND objcopy --input binary --output ${OBJ_FORMAT} --binary-architecture i386 \"${OLOCO_TEXT}\" openloco_text_section.o --rename-section .data=.loco_text,contents,alloc,load,code --writable-text
             DEPENDS segfiles
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )

--- a/distribution/mingw/ld_script_i386.xc
+++ b/distribution/mingw/ld_script_i386.xc
@@ -14,9 +14,10 @@ SECTIONS
 {
   /* Make the virtual address and file offset synced if the alignment is
      lower than the target page size. */
-  . = SIZEOF_HEADERS;
+  .loco_text      0x401000 : { *(.loco_text) }
+  .loco_data               : { *(.loco_data) }
   . = ALIGN(__section_alignment__);
-  .text  __image_base__ + ( __section_alignment__ < 0x1000 ? . : __section_alignment__ ) :
+  .text . + ( __section_alignment__ < 0x1000 ? . : __section_alignment__ ) :
   {
      KEEP(*(.init))
     *(.text)

--- a/distribution/mingw/ld_script_i386.xc
+++ b/distribution/mingw/ld_script_i386.xc
@@ -1,0 +1,320 @@
+/*
+GNU ld (GNU Binutils) 2.29
+  Supported emulations:
+   i386pe
+*/
+/* Default linker script, for normal executables */
+/* Copyright (C) 2014-2017 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+OUTPUT_FORMAT(pei-i386)
+SEARCH_DIR("/usr/i686-w64-mingw32/lib");
+SECTIONS
+{
+  /* Make the virtual address and file offset synced if the alignment is
+     lower than the target page size. */
+  . = SIZEOF_HEADERS;
+  . = ALIGN(__section_alignment__);
+  .text  __image_base__ + ( __section_alignment__ < 0x1000 ? . : __section_alignment__ ) :
+  {
+     KEEP(*(.init))
+    *(.text)
+    *(SORT(.text$*))
+     *(.text.*)
+     *(.gnu.linkonce.t.*)
+    *(.glue_7t)
+    *(.glue_7)
+     ___CTOR_LIST__ = .; __CTOR_LIST__ = . ;
+			LONG (-1);*(.ctors); *(.ctor); *(SORT(.ctors.*));  LONG (0);
+     ___DTOR_LIST__ = .; __DTOR_LIST__ = . ;
+			LONG (-1); *(.dtors); *(.dtor); *(SORT(.dtors.*));  LONG (0);
+     KEEP (*(.fini))
+    /* ??? Why is .gcc_exc here?  */
+     *(.gcc_exc)
+    PROVIDE (etext = .);
+    PROVIDE (_etext = .);
+     KEEP (*(.gcc_except_table))
+  }
+  /* The Cygwin32 library uses a section to avoid copying certain data
+     on fork.  This used to be named ".data".  The linker used
+     to include this between __data_start__ and __data_end__, but that
+     breaks building the cygwin32 dll.  Instead, we name the section
+     ".data_cygwin_nocopy" and explicitly include it after __data_end__. */
+  .data BLOCK(__section_alignment__) :
+  {
+    __data_start__ = . ;
+    *(.data)
+    *(.data2)
+    *(SORT(.data$*))
+    KEEP(*(.jcr))
+    __data_end__ = . ;
+    *(.data_cygwin_nocopy)
+  }
+  .rdata BLOCK(__section_alignment__) :
+  {
+    *(.rdata)
+             *(SORT(.rdata$*))
+    __rt_psrelocs_start = .;
+    KEEP(*(.rdata_runtime_pseudo_reloc))
+    __rt_psrelocs_end = .;
+  }
+  __rt_psrelocs_size = __rt_psrelocs_end - __rt_psrelocs_start;
+  ___RUNTIME_PSEUDO_RELOC_LIST_END__ = .;
+  __RUNTIME_PSEUDO_RELOC_LIST_END__ = .;
+  ___RUNTIME_PSEUDO_RELOC_LIST__ = . - __rt_psrelocs_size;
+  __RUNTIME_PSEUDO_RELOC_LIST__ = . - __rt_psrelocs_size;
+  .eh_frame BLOCK(__section_alignment__) :
+  {
+    KEEP(*(.eh_frame*))
+  }
+  .pdata BLOCK(__section_alignment__) :
+  {
+    KEEP(*(.pdata*))
+  }
+  .bss BLOCK(__section_alignment__) :
+  {
+    __bss_start__ = . ;
+    *(.bss)
+    *(COMMON)
+    __bss_end__ = . ;
+  }
+  .edata BLOCK(__section_alignment__) :
+  {
+    *(.edata)
+  }
+  /DISCARD/ :
+  {
+    *(.debug$S)
+    *(.debug$T)
+    *(.debug$F)
+    *(.drectve)
+     *(.note.GNU-stack)
+     *(.gnu.lto_*)
+  }
+  .idata BLOCK(__section_alignment__) :
+  {
+    /* This cannot currently be handled with grouped sections.
+	See pe.em:sort_sections.  */
+    KEEP (SORT(*)(.idata$2))
+    KEEP (SORT(*)(.idata$3))
+    /* These zeroes mark the end of the import list.  */
+    LONG (0); LONG (0); LONG (0); LONG (0); LONG (0);
+    KEEP (SORT(*)(.idata$4))
+    __IAT_start__ = .;
+    KEEP (SORT(*)(.idata$5))
+    __IAT_end__ = .;
+    KEEP (SORT(*)(.idata$6))
+    KEEP (SORT(*)(.idata$7))
+  }
+  .CRT BLOCK(__section_alignment__) :
+  {
+    ___crt_xc_start__ = . ;
+    KEEP (*(SORT(.CRT$XC*)))  /* C initialization */
+    ___crt_xc_end__ = . ;
+    ___crt_xi_start__ = . ;
+    KEEP (*(SORT(.CRT$XI*)))  /* C++ initialization */
+    ___crt_xi_end__ = . ;
+    ___crt_xl_start__ = . ;
+    KEEP (*(SORT(.CRT$XL*)))  /* TLS callbacks */
+    /* ___crt_xl_end__ is defined in the TLS Directory support code */
+    ___crt_xp_start__ = . ;
+    KEEP (*(SORT(.CRT$XP*)))  /* Pre-termination */
+    ___crt_xp_end__ = . ;
+    ___crt_xt_start__ = . ;
+    KEEP (*(SORT(.CRT$XT*)))  /* Termination */
+    ___crt_xt_end__ = . ;
+  }
+  /* Windows TLS expects .tls$AAA to be at the start and .tls$ZZZ to be
+     at the end of section.  This is important because _tls_start MUST
+     be at the beginning of the section to enable SECREL32 relocations with TLS
+     data.  */
+  .tls BLOCK(__section_alignment__) :
+  {
+    ___tls_start__ = . ;
+    KEEP (*(.tls$AAA))
+    KEEP (*(.tls))
+    KEEP (*(.tls$))
+    KEEP (*(SORT(.tls$*)))
+    KEEP (*(.tls$ZZZ))
+    ___tls_end__ = . ;
+  }
+  .endjunk BLOCK(__section_alignment__) :
+  {
+    /* end is deprecated, don't use it */
+    PROVIDE (end = .);
+    PROVIDE ( _end = .);
+     __end__ = .;
+  }
+  .rsrc BLOCK(__section_alignment__) : SUBALIGN(4)
+  {
+    KEEP (*(.rsrc))
+    KEEP (*(.rsrc$*))
+  }
+  .reloc BLOCK(__section_alignment__) :
+  {
+    *(.reloc)
+  }
+  .stab BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.stab)
+  }
+  .stabstr BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.stabstr)
+  }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section.  Unlike other targets that fake this by putting the
+     section VMA at 0, the PE format will not allow it.  */
+  /* DWARF 1.1 and DWARF 2.  */
+  .debug_aranges BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_aranges)
+  }
+  .zdebug_aranges BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_aranges)
+  }
+  .debug_pubnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_pubnames)
+  }
+  .zdebug_pubnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_pubnames)
+  }
+  .debug_pubtypes BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_pubtypes)
+  }
+  .zdebug_pubtypes BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_pubtypes)
+  }
+  /* DWARF 2.  */
+  .debug_info BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_info .gnu.linkonce.wi.*)
+  }
+  .zdebug_info BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_info .zdebug.gnu.linkonce.wi.*)
+  }
+  .debug_abbrev BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_abbrev)
+  }
+  .zdebug_abbrev BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_abbrev)
+  }
+  .debug_line BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_line)
+  }
+  .zdebug_line BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_line)
+  }
+  .debug_frame BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_frame*)
+  }
+  .zdebug_frame BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_frame*)
+  }
+  .debug_str BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_str)
+  }
+  .zdebug_str BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_str)
+  }
+  .debug_loc BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_loc)
+  }
+  .zdebug_loc BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_loc)
+  }
+  .debug_macinfo BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_macinfo)
+  }
+  .zdebug_macinfo BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_macinfo)
+  }
+  /* SGI/MIPS DWARF 2 extensions.  */
+  .debug_weaknames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_weaknames)
+  }
+  .zdebug_weaknames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_weaknames)
+  }
+  .debug_funcnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_funcnames)
+  }
+  .zdebug_funcnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_funcnames)
+  }
+  .debug_typenames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_typenames)
+  }
+  .zdebug_typenames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_typenames)
+  }
+  .debug_varnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_varnames)
+  }
+  .zdebug_varnames BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_varnames)
+  }
+  .debug_macro BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_macro)
+  }
+  .zdebug_macro BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_macro)
+  }
+  /* DWARF 3.  */
+  .debug_ranges BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_ranges)
+  }
+  .zdebug_ranges BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_ranges)
+  }
+  /* DWARF 4.  */
+  .debug_types BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_types .gnu.linkonce.wt.*)
+  }
+  .zdebug_types BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_types .gnu.linkonce.wt.*)
+  }
+  /* For Go and Rust.  */
+  .debug_gdb_scripts BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.debug_gdb_scripts)
+  }
+  .zdebug_gdb_scripts BLOCK(__section_alignment__) (NOLOAD) :
+  {
+    *(.zdebug_gdb_scripts)
+  }
+}

--- a/src/openloco/graphics/gfx.cpp
+++ b/src/openloco/graphics/gfx.cpp
@@ -55,7 +55,7 @@ namespace openloco::gfx
     void load_g1()
     {
         auto g1Path = environment::get_path(environment::path_id::g1);
-        std::ifstream stream(g1Path, std::ios::in | std::ios::binary);
+        std::ifstream stream(g1Path.make_preferred().string(), std::ios::in | std::ios::binary);
         if (!stream)
         {
             throw std::runtime_error("Opening g1 file failed.");

--- a/src/openloco/interop/hook.cpp
+++ b/src/openloco/interop/hook.cpp
@@ -213,8 +213,8 @@ namespace openloco::interop
         write_memory(address, data, sizeof(data));
     }
 
-    static void* _smallHooks;
-    static uint8_t* _offset;
+    static void* _smallHooks = nullptr;
+    static uint8_t* _offset = nullptr;
 
     static void* make_jump(uint32_t address, void* fn)
     {
@@ -223,7 +223,7 @@ namespace openloco::interop
         {
             size_t size = 20 * 500;
 #ifdef _WIN32
-            _hookTableAddress = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+            _smallHooks = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
             _smallHooks = mmap(NULL, size, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (_smallHooks == MAP_FAILED)
@@ -231,8 +231,8 @@ namespace openloco::interop
                 perror("mmap");
                 exit(1);
             }
-            _offset = static_cast<uint8_t*>(_smallHooks);
 #endif // _WIN32
+            _offset = static_cast<uint8_t*>(_smallHooks);
         }
 
         int i = 0;

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -14,6 +14,11 @@
 #include "../utility/string.hpp"
 #include "platform.h"
 
+int main(int argc, const char** argv)
+{
+    return 0;
+}
+
 namespace openloco::platform
 {
     uint32_t get_time()

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -10,12 +10,14 @@
 #include <shlobj.h>
 #include <windows.h>
 
+#include "../openloco.h"
 #include "../ui.h"
 #include "../utility/string.hpp"
 #include "platform.h"
 
 int main(int argc, const char** argv)
 {
+    openloco::main();
     return 0;
 }
 


### PR DESCRIPTION
This is proof-of-concept until validated with hooks installed.

This provides an implementation of section extraction and linking them at fixed place for mingw toolchain.

Generated openloco.exe has following sections, as reported by `objdump -h`:

```

openloco.exe:     file format pei-i386

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .loco_text    000d6000  00401000  00401000  00000600  2**2
                  CONTENTS, ALLOC, LOAD, CODE
  1 .loco_data    00c8b000  004d7000  004d7000  000d6600  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  2 .text         0001697c  01163000  01163000  00d61600  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE, DATA
  3 .data         00000064  0117a000  0117a000  00d78000  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  4 .rdata        00008278  0117b000  0117b000  00d78200  2**5
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  5 .bss          000016f0  01184000  01184000  00000000  2**5
                  ALLOC
  6 .edata        0000004d  01186000  01186000  00d80600  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  7 .idata        00001f84  01187000  01187000  00d80800  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  8 .CRT          00000034  01189000  01189000  00d82800  2**2
                  CONTENTS, ALLOC, LOAD, DATA
  9 .tls          00000020  0118a000  0118a000  00d82a00  2**2
                  CONTENTS, ALLOC, LOAD, DATA
 10 .reloc        00000c64  0118b000  0118b000  00d82c00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
 11 .debug_aranges 000004f8  0118c000  0118c000  00d83a00  2**3
                  CONTENTS, READONLY, DEBUGGING
 12 .debug_info   00073fd5  0118d000  0118d000  00d84000  2**0
                  CONTENTS, READONLY, DEBUGGING
 13 .debug_abbrev 0000442d  01201000  01201000  00df8000  2**0
                  CONTENTS, READONLY, DEBUGGING
 14 .debug_line   000056a3  01206000  01206000  00dfc600  2**0
                  CONTENTS, READONLY, DEBUGGING
 15 .debug_frame  0000158c  0120c000  0120c000  00e01e00  2**2
                  CONTENTS, READONLY, DEBUGGING
 16 .debug_str    00000bed  0120e000  0120e000  00e03400  2**0
                  CONTENTS, READONLY, DEBUGGING
 17 .debug_loc    00007218  0120f000  0120f000  00e04000  2**0
                  CONTENTS, READONLY, DEBUGGING
 18 .debug_ranges 00000500  01217000  01217000  00e0b400  2**0
                  CONTENTS, READONLY, DEBUGGING

```