### PR TITLE
Fix load_g1() when using boost

### DIFF
--- a/src/openloco/graphics/gfx.cpp
+++ b/src/openloco/graphics/gfx.cpp
@@ -55,7 +55,11 @@ namespace openloco::gfx
     void load_g1()
     {
         auto g1Path = environment::get_path(environment::path_id::g1);
+#ifdef _OPENLOCO_USE_BOOST_FS_
         std::ifstream stream(g1Path.make_preferred().string(), std::ios::in | std::ios::binary);
+#else
+        std::ifstream stream(g1Path, std::ios::in | std::ios::binary);
+#endif
         if (!stream)
         {
             throw std::runtime_error("Opening g1 file failed.");

--- a/src/openloco/graphics/gfx.cpp
+++ b/src/openloco/graphics/gfx.cpp
@@ -55,7 +55,7 @@ namespace openloco::gfx
     void load_g1()
     {
         auto g1Path = environment::get_path(environment::path_id::g1);
-        std::ifstream stream(g1Path, std::ios::in | std::ios::binary);
+        std::ifstream stream(g1Path.make_preferred().string(), std::ios::in | std::ios::binary);
         if (!stream)
         {
             throw std::runtime_error("Opening g1 file failed.");


### PR DESCRIPTION
As things stand compilation fails on macOS as the constructor for `std::ifstream` doesn't like `boost::filesystem::path` (see exact error below).

```
/Library/Developer/CommandLineTools/usr/include/c++/v1/fstream:1016:14: note: candidate constructor not viable: no known conversion from
      'boost::filesystem::path' to 'const char *' for 1st argument
    explicit basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in);
             ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/fstream:1018:14: note: candidate constructor not viable: no known conversion from
      'boost::filesystem::path' to 'const string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >') for 1st argument
    explicit basic_ifstream(const string& __s, ios_base::openmode __mode = ios_base::in);
             ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/fstream:1022:5: note: candidate constructor not viable: requires single argument '__rhs',
      but 2 arguments were provided
    basic_ifstream(basic_ifstream&& __rhs);
```