### PR TITLE
Fix path seperator with filesystem in get_directory

### DIFF
--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -128,7 +128,10 @@ namespace openloco::ui::windows
         if (path.has_extension())
         {
             // Concatenate with empty dir to ensure path ends with separator
-            return path.parent_path() / "";
+            // concat only takes fs::path or string, so we wrap it
+            std::string sep(1, fs::path::preferred_separator);
+            return path.parent_path().concat(sep);
+
         }
         else
         {

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -127,9 +127,7 @@ namespace openloco::ui::windows
     {
         if (path.has_extension())
         {
-            // Concatenate with empty dir to ensure path ends with separator
-            // concat only takes fs::path or string, so we wrap it
-            std::string sep(1, fs::path::preferred_separator);
+            std::basic_string<fs::path::value_type> sep(1, fs::path::preferred_separator);
             return path.parent_path().concat(sep);
 
         }

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -129,7 +129,6 @@ namespace openloco::ui::windows
         {
             std::basic_string<fs::path::value_type> sep(1, fs::path::preferred_separator);
             return path.parent_path().concat(sep);
-
         }
         else
         {


### PR DESCRIPTION
The original issue is that if one appends the null string, since `p.native() begins with a directory separator`, it will not append the separator. (see http://en.cppreference.com/w/cpp/experimental/fs/path/append).

The filesystem spec is rather... interesting. The preferred separator is a char, but this cannot be concatenated nor appended to a path. Fun 😬 

