### PR TITLE
Change user paths and disable file checks

### DIFF
--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -12,8 +12,8 @@
 #endif
 
 #include "config.h"
+#include "environment.h"
 #include "interop/interop.hpp"
-#include "platform/platform.h"
 
 using namespace openloco::interop;
 
@@ -27,9 +27,6 @@ namespace openloco::config
 {
     static loco_global<config_t, 0x0050AEB4> _config;
     static new_config _new_config;
-
-    static fs::path get_new_config_path();
-    static fs::path get_user_directory();
 
     config_t& get()
     {
@@ -57,7 +54,7 @@ namespace openloco::config
 
     new_config& read_new_config()
     {
-        auto configPath = get_new_config_path();
+        auto configPath = environment::get_path(environment::path_id::openloco_cfg);
 #ifdef _OPENLOCO_USE_BOOST_FS_
         std::ifstream stream(configPath.string());
 #else
@@ -73,7 +70,7 @@ namespace openloco::config
 
     void write_new_config()
     {
-        auto configPath = get_new_config_path();
+        auto configPath = environment::get_path(environment::path_id::openloco_cfg);
         auto dir = configPath.parent_path();
         if (!fs::is_directory(dir))
         {
@@ -103,10 +100,5 @@ namespace openloco::config
             stream << _new_config.loco_install_path << std::endl;
             stream << _new_config.breakdowns_disabled << std::endl;
         }
-    }
-
-    static fs::path get_new_config_path()
-    {
-        return platform::get_user_directory() / "openloco.cfg";
     }
 }

--- a/src/openloco/envionment.cpp
+++ b/src/openloco/envionment.cpp
@@ -6,6 +6,7 @@
 #include "utility/collection.hpp"
 #include "utility/string.hpp"
 #include <cstring>
+#include <fstream>
 #include <iostream>
 
 using namespace openloco::interop;
@@ -20,6 +21,7 @@ namespace openloco::environment
     loco_global_array<char, 257, 0x0050B518> _path_landscapes;
     loco_global_array<char, 257, 0x0050B635> _path_objects;
 
+    static fs::path get_base_path(path_id id);
     static fs::path get_sub_path(path_id id);
 #ifndef _WIN32
     static fs::path find_similar_file(const fs::path& path);
@@ -150,7 +152,7 @@ namespace openloco::environment
     // 0x004416B5
     fs::path get_path(path_id id)
     {
-        auto basePath = get_loco_install_path();
+        auto basePath = get_base_path(id);
         auto subPath = get_sub_path(id);
         auto result = basePath / subPath;
         if (!fs::exists(result))
@@ -190,18 +192,33 @@ namespace openloco::environment
         set_directory(_path_objects, basePath / "ObjData/*.DAT");
     }
 
+    static fs::path get_base_path(path_id id)
+    {
+        switch (id)
+        {
+            case path_id::plugin1:
+            case path_id::plugin2:
+            case path_id::gamecfg:
+            case path_id::scores:
+            case path_id::openloco_cfg:
+                return platform::get_user_directory();
+            default:
+                return get_loco_install_path();
+        }
+    }
+
     static fs::path get_sub_path(path_id id)
     {
         static constexpr const char* paths[] = {
             "Data/g1.DAT",
-            "Data/PLUGIN.DAT",
-            "Data/PLUGIN2.DAT",
+            "plugin.dat",
+            "plugin2.dat",
             "Data/CSS1.DAT",
             "Data/CSS2.DAT",
             "Data/CSS3.DAT",
             "Data/CSS4.DAT",
             "Data/CSS5.DAT",
-            "Data/GAME.CFG",
+            "game.cfg",
             "Data/KANJI.DAT",
             "Data/20s1.DAT",
             "Data/20s2.DAT",
@@ -233,14 +250,15 @@ namespace openloco::environment
             "Data/20s5.DAT",
             "Data/20s6.DAT",
             "Data/title.dat",
-            "Data/Scores.DAT",
+            "scores.dat",
             "Scenarios/Boulder Breakers.SC5",
             "Data/TUT1024_1.DAT",
             "Data/TUT1024_2.DAT",
             "Data/TUT1024_3.DAT",
             "Data/TUT800_1.DAT",
             "Data/TUT800_2.DAT",
-            "Data/TUT800_3.DAT"
+            "Data/TUT800_3.DAT",
+            "openloco.cfg"
         };
 
         size_t index = (size_t)id;

--- a/src/openloco/environment.h
+++ b/src/openloco/environment.h
@@ -64,6 +64,7 @@ namespace openloco::environment
         tut800_1,
         tut800_2,
         tut800_3,
+        openloco_cfg,
     };
 
     fs::path get_path(path_id id);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -207,34 +207,6 @@ namespace openloco
         call(0x004BE621, regs);
     }
 
-    // 0x0044155B
-    static void check_game_file_exists(int i)
-    {
-        registers regs;
-        regs.ebx = i;
-        call(0x0044155B, regs);
-    }
-
-    // 0x0044154B
-    static void check_game_files_exist()
-    {
-        for (int i = 0; i < 48; i++)
-        {
-            check_game_file_exists(i);
-        }
-    }
-
-    // 0x004414C5
-    static void check_game_files_are_valid()
-    {
-        call(0x004414C5);
-    }
-
-    static void sub_441444()
-    {
-        call(0x00441444);
-    }
-
     // 0x00441400
     static void startup_checks()
     {
@@ -242,12 +214,11 @@ namespace openloco
         {
             exit_with_error(61, 1016);
         }
-        else
-        {
-            check_game_files_exist();
-            check_game_files_are_valid();
-            sub_441444();
-        }
+
+        // Originally the game would check that all the game
+        // files exist are some have the correct checksum. We
+        // do not need to do this anymore, the game should work
+        // with g1 alone and some objects?
     }
 
     // 0x004C57C0


### PR DESCRIPTION
This allows the game to run without the following files pre-existing:
* game.cfg
* plugin.dat
* plugin2.dat
* scores.dat

They are also now read and written to the user directory for OpenLoco and use lower case names.

Existing players will need to copy scores.dat to `%APPDATA%\OpenLoco` if they wish to transfer their scenario progress.