### PR TITLE
Add a docker-compose file for each compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin.*/
 lib/
 
 ## Visual Studio Code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  openloco-gcc32:
+    image: openrct2/openloco:ubuntu-i686
+    working_dir: /openloco/bin.gcc
+    volumes:
+      - .:/openloco
+    entrypoint: bash
+    command: -c "cmake ../ -G Ninja -DCMAKE_BUILD_TYPE=release && ninja -k0"
+  openloco-clang32:
+    image: openrct2/openloco:ubuntu-i686
+    working_dir: /openloco/bin.clang
+    volumes:
+      - .:/openloco
+    entrypoint: bash
+    command: -c "cmake ../ -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=release && ninja -k0"
+  openloco-mingw32:
+    image: openrct2/openloco:fedora-mingw32
+    working_dir: /openloco/bin.mingw32
+    volumes:
+      - .:/openloco
+    entrypoint: bash
+    command: -c "cmake ../ -G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=release -DBOOST_ROOT=/usr/i686-w64-mingw32/sys-root/mingw/ && ninja -k0"


### PR DESCRIPTION
This allows you to run the CI jobs on your computer using docker.

```sh
# Run them individually
docker-compose up openloco-gcc32
docker-compose up openloco-clang32
docker-compose up openloco-mingw32

# Run them all in parallel
docker-compose up
```

This should allow anyone to easily "build" openloco either on Windows (10 pro+), macOS or any Linux distro.