### PR TITLE
Include Boost dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ OpenLoco requires original files of Chris Sawyer's Locomotion to play. It can be
 - cmake
 - make or ninja
 - [SDL2](https://www.libsdl.org/download-2.0.php)
+- [Boost](http://www.boost.org/) (macOS only, [see wiki](https://github.com/OpenRCT2/OpenLoco/wiki/Compilation-on-macOS))
 
 ---
 


### PR DESCRIPTION
macOS builds currently depend on Boost as a replacement for `std::filesystem`, which hasn't landed in its standard library yet. This PR adds this dependency to README.md