### PR TITLE
Rename envionment.cpp to environment.cpp

### DIFF
--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -1,5 +1,5 @@
-#include "config.h"
 #include "environment.h"
+#include "config.h"
 #include "interop/interop.hpp"
 #include "platform/platform.h"
 #include "ui.h"

--- a/src/openloco/openloco.vcxproj
+++ b/src/openloco/openloco.vcxproj
@@ -20,7 +20,7 @@
     <ClCompile Include="config.cpp" />
     <ClCompile Include="console.cpp" />
     <ClCompile Include="date.cpp" />
-    <ClCompile Include="envionment.cpp" />
+    <ClCompile Include="environment.cpp" />
     <ClCompile Include="industry.cpp" />
     <ClCompile Include="industrymgr.cpp" />
     <ClCompile Include="input.cpp" />


### PR DESCRIPTION
I really didn't want to make such a trivial PR, but this has been bugging me for a while now…