### PR TITLE
Add git branch and short sha1 hash to version info line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,31 @@ if (APPLE)
     set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/openssl/lib/pkgconfig")
 endif (APPLE)
 
+# Define current git branch
+execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE OPENLOCO_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+# Define short commit hash
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE OPENLOCO_COMMIT_SHA1_SHORT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+# To avoid unnecessary rebuilds, set the current branch and short sha1 hash
+# only for the one file that uses these definitions: version.cpp
+set_property(SOURCE ${CMAKE_SOURCE_DIR}/src/openloco/version.cpp
+    PROPERTY COMPILE_DEFINITIONS
+    OPENLOCO_BRANCH="${OPENLOCO_BRANCH}"
+    OPENLOCO_COMMIT_SHA1_SHORT="${OPENLOCO_COMMIT_SHA1_SHORT}")
+
 # Set some compiler features
 set(COMMON_COMPILE_OPTIONS "${COMMON_COMPILE_OPTIONS} -fstrict-aliasing -Werror -Wall")
 

--- a/src/openloco/version.cpp
+++ b/src/openloco/version.cpp
@@ -3,10 +3,20 @@
 // clang-format off
 #define NAME            "OpenLoco"
 #define VERSION         "18.02"
-#define VERSION_INFO    NAME " " VERSION
+#define VERSION_INFO    NAME ", v" VERSION
 // clang-format on
 
 namespace openloco
 {
-    const char version[] = VERSION_INFO;
+    const char version[] = VERSION_INFO
+#ifdef OPENLOCO_BRANCH
+        "-" OPENLOCO_BRANCH
+#endif
+#ifdef OPENLOCO_COMMIT_SHA1_SHORT
+        " build " OPENLOCO_COMMIT_SHA1_SHORT
+#endif
+#ifndef NDEBUG
+        " (DEBUG)"
+#endif
+        ;
 }


### PR DESCRIPTION
This adds the current git branch and short sha1 hash to the version info line on the title screen.

![screenshot_20180216_014441](https://user-images.githubusercontent.com/604665/36288452-f79796c8-12ba-11e8-8da8-0904e74fb421.png)
