### PR TITLE
Remove terraforming limits outside of scenario editor

### DIFF
--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -535,6 +535,43 @@ void openloco::interop::load_sections()
 #endif
 }
 
+static void register_terraform_hooks()
+{
+    /* Event 1: clear tool
+    ------------------------*/
+    // Remove size limit outside of scenario editor: will always be 10 instead of 5.
+    interop::write_nop(0x4BC75B, 0x4BC779 - 0x4BC75B);
+
+    /* Event 2: land tool
+    -----------------------*/
+    // Enable soil selection
+    // TODO: doesn't have any effect yet, and is in the way.
+    // interop::write_nop(0x4BC8CE, 0x4BC8D7 - 0x4BC8CE);
+
+    // Remove decrease size limit: enable mountain tool outside of scenario editor.
+    interop::write_nop(0x4BCA9E, 0x4BCAB1 - 0x4BCA9E);
+
+    // Remove increase size limit: will always be 10 instead of 5.
+    interop::write_nop(0x4BCADC, 0x4BCAFA - 0x4BCADC);
+
+    /* Event 3: water tool
+    ------------------------*/
+    // Remove size limit outside of scenario editor: will always be 10 instead of 5.
+    interop::write_nop(0x4BCE49, 0x4BCE67 - 0x4BCE49);
+
+    /* Event 4: trees and forests
+    -------------------------------*/
+    // Enable forest placement outside of scenario editor.
+    // TODO: placing a forest currently does not cost any money.
+    interop::write_nop(0x4BB8AA, 0x4BB8B5 - 0x4BB8AA);
+
+    /* Event 5: fences
+    --------------------*/
+    // Don't disable fences tab
+    // TODO: don't decrease window.
+    interop::write_nop(0x4BCF6B, 0x4BCF7B - 0x4BCF6B);
+}
+
 void openloco::interop::register_hooks()
 {
     using namespace openloco::ui::windows;
@@ -542,6 +579,8 @@ void openloco::interop::register_hooks()
 #ifdef _NO_LOCO_WIN32_
     register_no_win32_hooks();
 #endif // _NO_LOCO_WIN32_
+
+    register_terraform_hooks();
 
     register_hook(
         0x004416B5,

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -542,6 +542,9 @@ static void register_terraform_hooks()
     // Remove size limit outside of scenario editor: will always be 10 instead of 5.
     interop::write_nop(0x4BC75B, 0x4BC779 - 0x4BC75B);
 
+    // Resize window to fit fifth tab.
+    interop::write_nop(0x4BC7CF, 0x4BC7DA - 0x4BC7CF);
+
     /* Event 2: land tool
     -----------------------*/
     // Enable soil selection
@@ -554,10 +557,16 @@ static void register_terraform_hooks()
     // Remove increase size limit: will always be 10 instead of 5.
     interop::write_nop(0x4BCADC, 0x4BCAFA - 0x4BCADC);
 
+    // Resize window to fit fifth tab.
+    interop::write_nop(0x4BCC01, 0x4BCC0C - 0x4BCC01);
+
     /* Event 3: water tool
     ------------------------*/
     // Remove size limit outside of scenario editor: will always be 10 instead of 5.
     interop::write_nop(0x4BCE49, 0x4BCE67 - 0x4BCE49);
+
+    // Resize window to fit fifth tab.
+    interop::write_nop(0x4BCEBD, 0x4BCEC8 - 0x4BCEBD);
 
     /* Event 4: trees and forests
     -------------------------------*/
@@ -568,8 +577,10 @@ static void register_terraform_hooks()
     /* Event 5: fences
     --------------------*/
     // Don't disable fences tab
-    // TODO: don't decrease window.
     interop::write_nop(0x4BCF6B, 0x4BCF7B - 0x4BCF6B);
+
+    // Show in menu
+    interop::write_nop(0x43A485, 0x43A490 - 0x43A485);
 }
 
 void openloco::interop::register_hooks()


### PR DESCRIPTION
This PR removes (no-ops) the terraforming limits outside of the scenario editor. Fixes #127.

Initially, I thought it best to leave changing these until the window was implemented, but it turned out to be fairly straightforward.

* Make in-game follow the same restrictions as the scenario editor for clear tool, water tool
* Enables use of the mountain tool outside of the scenario editor
* Enables placing forest and walls/fences outside of the scenario editor

## Screenshot

![screenshot_20180520_215952](https://user-images.githubusercontent.com/604665/40283081-27d4b0de-5c79-11e8-956a-435d089aba6b.png)

## Caveats

* [ ] Placing a forest currently does not cost any money. It's not computed, so not a trivial change.
* [ ] I can easily change the soil selection to appear, too, but there appears to be another check for it to be applied.