### PR TITLE
Use `git describe` to express version in terms of closest tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,16 @@ if (APPLE)
     set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/openssl/lib/pkgconfig")
 endif (APPLE)
 
+# Describe current version in terms of closest tag
+execute_process(
+    COMMAND git describe HEAD
+    COMMAND sed -E "s/-g.+$//"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE OPENLOCO_VERSION_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    # ERROR_QUIET
+)
+
 # Define current git branch
 execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
@@ -43,6 +53,7 @@ execute_process(
 # only for the one file that uses these definitions: version.cpp
 set_property(SOURCE ${CMAKE_SOURCE_DIR}/src/openloco/version.cpp
     PROPERTY COMPILE_DEFINITIONS
+    OPENLOCO_VERSION_TAG="${OPENLOCO_VERSION_TAG}"
     OPENLOCO_BRANCH="${OPENLOCO_BRANCH}"
     OPENLOCO_COMMIT_SHA1_SHORT="${OPENLOCO_COMMIT_SHA1_SHORT}")
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ install:
     Remove-Item -Recurse .\SDL2-2.0.7
 
     Pop-Location
+
+    $env:GIT_DESCRIBE = (git describe HEAD | sed -E "s/-g.+$//")
 configuration: Release
 build:
   verbosity: minimal

--- a/src/openloco/openloco.vcxproj
+++ b/src/openloco/openloco.vcxproj
@@ -48,6 +48,7 @@
       <!-- Define git information -->
       <PreprocessorDefinitions Condition="'$(APPVEYOR_REPO_BRANCH)'!=''">OPENLOCO_BRANCH="$(APPVEYOR_REPO_BRANCH)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(APPVEYOR_REPO_COMMIT_SHORT)'!=''">OPENLOCO_COMMIT_SHA1_SHORT="$(APPVEYOR_REPO_COMMIT_SHORT)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(GIT_DESCRIBE)'!=''">OPENLOCO_VERSION_TAG="$(GIT_DESCRIBE)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="viewportmgr.cpp" />
     <ClCompile Include="window.cpp" />

--- a/src/openloco/version.cpp
+++ b/src/openloco/version.cpp
@@ -1,22 +1,29 @@
 #include "openloco.h"
 
-// clang-format off
-#define NAME            "OpenLoco"
-#define VERSION         "18.02.2"
-#define VERSION_INFO    NAME ", v" VERSION
-// clang-format on
+#define NAME "OpenLoco"
+#define VERSION "18.02.2"
 
 namespace openloco
 {
-    const char version[] = VERSION_INFO
-#ifdef OPENLOCO_BRANCH
-        "-" OPENLOCO_BRANCH
+    const char version[] = NAME ", "
+#ifdef OPENLOCO_VERSION_TAG
+        OPENLOCO_VERSION_TAG
+#else
+                                "v" VERSION
 #endif
-#ifdef OPENLOCO_COMMIT_SHA1_SHORT
-        " build " OPENLOCO_COMMIT_SHA1_SHORT
+#if defined(OPENLOCO_BRANCH) || defined(OPENLOCO_COMMIT_SHA1_SHORT) || !defined(NDEBUG)
+                                " ("
+#if defined(OPENLOCO_BRANCH) && defined(OPENLOCO_COMMIT_SHA1_SHORT)
+        OPENLOCO_COMMIT_SHA1_SHORT " on " OPENLOCO_BRANCH
+#elif defined(OPENLOCO_COMMIT_SHA1_SHORT)
+        OPENLOCO_COMMIT_SHA1_SHORT
+#elif defined(OPENLOCO_BRANCH)
+        OPENLOCO_BRANCH
 #endif
 #ifndef NDEBUG
-        " (DEBUG)"
+                                ", DEBUG"
+#endif
+                                ")"
 #endif
         ;
 }


### PR DESCRIPTION
This PR introduces the use of `git describe` to express the version number in terms of the last tag by appending the number of commits since the release was tagged.

Before:
![screenshot_20180616_131107](https://user-images.githubusercontent.com/604665/41498189-49036f5e-7167-11e8-9495-af7099956f86.png)

After:
![screenshot_20180616_131044](https://user-images.githubusercontent.com/604665/41498188-45e9cf48-7167-11e8-888a-86ef8b3b6212.png)

- [x] We will need to re-create the `v18.02` tag to be an annotated tag rather than a lightweight one.
- [x] AppVeyor still needs to be updated.