### PR TITLE
Directory browsing on Linux and macOS

### DIFF
--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -645,71 +645,6 @@ void openloco::interop::register_hooks()
         });
 
     register_hook(
-        0x00445AB9,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            auto result = prompt_browse(
-                (browse_type)regs.al,
-                (char*)regs.ecx,
-                (const char*)regs.edx,
-                (const char*)regs.ebx);
-            regs.eax = result ? 1 : 0;
-            return 0;
-        });
-
-    // TODO: move to promptbrowsewnd::up_one_level
-    register_hook(
-        0x00446E2F,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            // ui::windows::up_one_level();
-            loco_global<char[512], 0x009D9E84> _directory;
-            char* ptr = _directory;
-            while (*ptr != '\0')
-                ptr++;
-
-            ptr--;
-            if (*ptr == '\\' || *ptr == '/')
-                ptr--;
-
-            while (ptr != _directory && *ptr != '\\' && *ptr != '/')
-                ptr--;
-
-            if (*ptr == '\\' || *ptr == '/')
-                ptr++;
-
-            *ptr = '\0';
-
-            call(0x00446A93);
-            return 0;
-        });
-
-    // TODO: move to promptbrowsewnd::append_directory
-    register_hook(
-        0x00446E62,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            // ui::windows::append_directory();
-            loco_global<char[512], 0x009D9E84> _directory;
-            char* dst = _directory;
-            while (*dst != '\0')
-                dst++;
-
-            char* src = (char*)regs.ebp;
-            while (*src != '\0')
-            {
-                *dst++ = *src++;
-            }
-
-#ifdef _NO_LOCO_WIN32_
-            *dst++ = '/';
-#else
-            *dst++ = '\\';
-#endif
-            *dst = '\0';
-
-            call(0x00446A93);
-            return 0;
-        });
-
-    register_hook(
         0x00446F6B,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             auto result = prompt_ok_cancel(regs.eax);
@@ -790,8 +725,9 @@ void openloco::interop::register_hooks()
             return 0;
         });
 
-    ui::windowmgr::register_hooks();
+    ui::prompt_browse::register_hooks();
     ui::tooltip::register_hooks();
+    ui::windowmgr::register_hooks();
 
     register_hook(
         0x004AB655,

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -206,6 +206,8 @@ public:
     std::vector<openloco::environment::fs::path> fileList;
 };
 
+#define FILE_ATTRIBUTE_DIRECTORY 0x10
+
 FORCE_ALIGN_ARG_POINTER
 static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
 {
@@ -214,11 +216,6 @@ static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
     Session* data = new Session;
 
     openloco::environment::fs::path path = lpFileName;
-#ifdef _OPENLOCO_USE_BOOST_FS_
-    std::string format = path.filename().string();
-#else
-    std::string format = path.filename().u8string();
-#endif
     path.remove_filename();
 
     openloco::environment::fs::directory_iterator iter(path), end;
@@ -234,6 +231,16 @@ static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
 #else
     utility::strcpy_safe(out->cFilename, data->fileList[0].filename().u8string().c_str());
 #endif
+
+    if (openloco::environment::fs::is_directory(data->fileList[0]))
+    {
+        out->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
+    }
+    else
+    {
+        out->dwFileAttributes &= ~FILE_ATTRIBUTE_DIRECTORY;
+    }
+
     data->fileList.erase(data->fileList.begin());
     return data;
 }
@@ -252,6 +259,16 @@ static bool CDECL fn_FindNextFile(Session* data, FindFileData* out)
 #else
     utility::strcpy_safe(out->cFilename, data->fileList[0].filename().u8string().c_str());
 #endif
+
+    if (openloco::environment::fs::is_directory(data->fileList[0]))
+    {
+        out->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
+    }
+    else
+    {
+        out->dwFileAttributes &= ~FILE_ATTRIBUTE_DIRECTORY;
+    }
+
     data->fileList.erase(data->fileList.begin());
 
     return true;

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -656,6 +656,59 @@ void openloco::interop::register_hooks()
             return 0;
         });
 
+    // TODO: move to promptbrowsewnd::up_one_level
+    register_hook(
+        0x00446E2F,
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            // ui::windows::up_one_level();
+            loco_global<char[512], 0x009D9E84> _directory;
+            char* ptr = _directory;
+            while (*ptr != '\0')
+                ptr++;
+
+            ptr--;
+            if (*ptr == '\\' || *ptr == '/')
+                ptr--;
+
+            while (ptr != _directory && *ptr != '\\' && *ptr != '/')
+                ptr--;
+
+            if (*ptr == '\\' || *ptr == '/')
+                ptr++;
+
+            *ptr = '\0';
+
+            call(0x00446A93);
+            return 0;
+        });
+
+    // TODO: move to promptbrowsewnd::append_directory
+    register_hook(
+        0x00446E62,
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            // ui::windows::append_directory();
+            loco_global<char[512], 0x009D9E84> _directory;
+            char* dst = _directory;
+            while (*dst != '\0')
+                dst++;
+
+            char* src = (char*)regs.ebp;
+            while (*src != '\0')
+            {
+                *dst++ = *src++;
+            }
+
+#ifdef _NO_LOCO_WIN32_
+            *dst++ = '/';
+#else
+            *dst++ = '\\';
+#endif
+            *dst = '\0';
+
+            call(0x00446A93);
+            return 0;
+        });
+
     register_hook(
         0x00446F6B,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {

--- a/src/openloco/windowmgr.h
+++ b/src/openloco/windowmgr.h
@@ -106,11 +106,6 @@ namespace openloco::ui::windowmgr
 
 namespace openloco::ui::windows
 {
-    enum class browse_type
-    {
-        load = 1,
-        save = 2
-    };
 
     void construction_mouse_up(window& w, uint16_t widgetIndex);
     void station_2_scroll_paint(window& w, gfx::drawpixelinfo_t& dpi);
@@ -118,9 +113,19 @@ namespace openloco::ui::windows
     window* open_title_version();
     void sub_498E9B(window* w);
 
-    bool prompt_browse(browse_type type, char* path, const char* filter, const char* title);
     bool prompt_ok_cancel(string_id okButtonStringId);
     void map_center_on_view_point();
+}
+
+namespace openloco::ui::prompt_browse
+{
+    enum class browse_type
+    {
+        load = 1,
+        save = 2
+    };
+    bool open(browse_type type, char* path, const char* filter, const char* title);
+    void register_hooks();
 }
 
 namespace openloco::ui::textinput


### PR DESCRIPTION
Currently, all entries in the load/save window are taken as filenames on Linux and macOS. This PR changes things so they are recognised as directories when appropriate. It also implements simple directory browsing: navigating to a directory, and going up one level.

When we're implementing the load/save window properly, and we're no longer bound to Locomotion's internal data structures, I believe we should replace these with instances of `filesystem::path`. Until that time, I think this is a reasonable approach.

I'd like to move the functions for these hooks to `windows/promptbrowsewnd.cpp`\*, but as we currently don't have any header files I'm not sure what the best approach to that end would be.

\* Side note: I believe we should rename it to loadsavewnd.cpp or something similar.