### PR TITLE
Fix #169: segfault on startup in resize event

### DIFF
--- a/src/openloco/gui.cpp
+++ b/src/openloco/gui.cpp
@@ -163,12 +163,18 @@ namespace openloco::gui
         {
             window->width = uiWidth;
             window->height = uiHeight;
-            window->widgets[0].right = uiWidth;
-            window->widgets[0].bottom = uiHeight;
-            window->viewports[0]->width = uiWidth;
-            window->viewports[0]->height = uiHeight;
-            window->viewports[0]->view_width = uiWidth << window->viewports[0]->zoom;
-            window->viewports[0]->view_height = uiHeight << window->viewports[0]->zoom;
+            if (window->widgets)
+            {
+                window->widgets[0].right = uiWidth;
+                window->widgets[0].bottom = uiHeight;
+            }
+            if (window->viewports[0])
+            {
+                window->viewports[0]->width = uiWidth;
+                window->viewports[0]->height = uiHeight;
+                window->viewports[0]->view_width = uiWidth << window->viewports[0]->zoom;
+                window->viewports[0]->view_height = uiHeight << window->viewports[0]->zoom;
+            }
         }
 
         window = windowmgr::find(window_type::toolbar_top);

--- a/src/openloco/windowmgr.cpp
+++ b/src/openloco/windowmgr.cpp
@@ -26,7 +26,13 @@ namespace openloco::ui::windowmgr
     struct WindowList
     {
         window* begin() const { return &_windows[0]; };
-        window* end() const { return _windows_end; };
+        window* end() const
+        {
+            if (_windows_end)
+                return _windows_end;
+            else
+                return &_windows[0];
+        };
     };
 
     void register_hooks()


### PR DESCRIPTION
Some fields are not initialised early enough and WindowList::end() can
return nullptr, whereas the matching begin() returns a valid pointer. To
address this issue, if the relevant memory is still uninitialised,
return a pointer to first element