### PR TITLE
Fix config directory initialisation on non-Windows

### DIFF
--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -158,13 +158,18 @@ namespace openloco::environment
         if (!fs::exists(result))
         {
 #ifndef _WIN32
-            if (auto similarResult = find_similar_file(result); similarResult.empty())
+            auto similarResult = find_similar_file(result);
+            if (similarResult.empty())
             {
-#endif
                 std::cerr << "File not found: " << result << std::endl;
-#ifndef _WIN32
+            }
+            else
+            {
                 result = similarResult;
             }
+#else
+
+            std::cerr << "File not found: " << result << std::endl;
 #endif
         }
         return result;


### PR DESCRIPTION
`result` was not assigned when a `similarResult` was indeed found.