### PR TITLE
Force-align arg pointers for more hooks

### DIFF
--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -335,6 +335,7 @@ static uint32_t STDCALL lib_DirectSoundCreate(void* lpGuid, void* ppDS, void* pU
     return DSERR_NODRIVER;
 }
 
+FORCE_ALIGN_ARG_POINTER
 static uint32_t STDCALL lib_CreateRectRgn(int x1, int y1, int x2, int y2)
 {
     console::log("CreateRectRgn(%d, %d, %d, %d)", x1, y1, x2, y2);
@@ -361,6 +362,7 @@ static bool STDCALL lib_DeleteFileA(char* lpFileName)
     return false;
 }
 
+FORCE_ALIGN_ARG_POINTER
 static bool STDCALL lib_WriteFile(
     FILE* hFile,
     char* buffer,


### PR DESCRIPTION
An unfortunate side-effect of 5ec3aa700bebabb489ca942d951ab9d5d81f86c8 is a crash on startup on macOS. Adding `FORCE_ALIGN_ARG_POINTER` to the hooks `lib_CreateRectRgn` and `lib_WriteFile` fixes this.