### PR TITLE
Move macOS boost formula dependency to Dependencies repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
-            - brew install https://raw.githubusercontent.com/marijnvdwerf/openloco-dependencies/v1/Formula/boost.rb
+            - brew install https://raw.githubusercontent.com/OpenRCT2/OpenLoco-Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenRCT2/OpenLoco-Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip dependencies.zip -d vcpkg/
@@ -59,7 +59,7 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
-            - brew install https://raw.githubusercontent.com/marijnvdwerf/openloco-dependencies/v1/Formula/boost.rb
+            - brew install https://raw.githubusercontent.com/OpenRCT2/OpenLoco-Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenRCT2/OpenLoco-Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip dependencies.zip -d vcpkg/


### PR DESCRIPTION
This PR moves the macOS boost dependency, both its formula and bottles, to our OpenLoco Dependencies repository.